### PR TITLE
Bugfix for the CI scripts that search for bad style

### DIFF
--- a/ci/10-trailing_whitespaces.sh
+++ b/ci/10-trailing_whitespaces.sh
@@ -12,8 +12,9 @@ echo -n ">>> Seaching for lines with trailing whitespaces..."
 # Search for trailing whitespaces
 FOUND=0
 for FILE in $(find $FOLDER -regex $FILES); do
-    if egrep -q " +$" $FILE ; then
-        echo -e "\nFound:\t$FILE"
+    if egrep -q " +$" $FILE; then
+        [ $FOUND == 0 ] && echo -e "\tError."
+        echo -e "Found:\t$FILE"
         FOUND=1
     fi
 done

--- a/ci/20-trailing_newline.sh
+++ b/ci/20-trailing_newline.sh
@@ -14,8 +14,9 @@ FOUND=0
 for FILE in $(find $FOLDER -regex $FILES); do
     LASTLINE=$(tail -n 1 $FILE; echo x)
     LASTLINE=${LASTLINE%x}
-    if [ "${LASTLINE: -1}" != $'\n' ] ; then
-        echo -e "\nFound:\t$FILE"
+    if [ "${LASTLINE: -1}" != $'\n' ]; then
+        [ $FOUND == 0 ] && echo -e "\tError."
+        echo -e "Found:\t$FILE"
         FOUND=1
     fi
 done

--- a/ci/30-line_endings.sh
+++ b/ci/30-line_endings.sh
@@ -12,8 +12,9 @@ echo -n ">>> Seaching for files with wrong line endings..."
 # Search wrong line endings
 FOUND=0
 for FILE in $(find $FOLDER -regex $FILES); do
-    if grep -q $'\r' $FILE ; then
-        echo -e "\nFound: $FILE"
+    if grep -q $'\r' $FILE; then
+        [ $FOUND == 0 ] && echo -e "\tError."
+        echo -e "Found: $FILE"
         FOUND=1
     fi
 done

--- a/ci/40-indentation.sh
+++ b/ci/40-indentation.sh
@@ -12,8 +12,9 @@ echo -n ">>> Seaching for files with tab characters..."
 # Search for files with tab characters
 FOUND=0
 for FILE in $(find $FOLDER -regex $FILES); do
-    if grep -q $'\t' $FILE ; then
-        echo -e "\nFound: $FILE"
+    if grep -q $'\t' $FILE; then
+        [ $FOUND == 0 ] && echo -e "\t\tError."
+        echo -e "Found: $FILE"
         FOUND=1
     fi
 done

--- a/ci/50-line_length.sh
+++ b/ci/50-line_length.sh
@@ -13,8 +13,9 @@ echo -n ">>> Seaching for lines exceeding the length limit..."
 # Seach for lines that are too long
 FOUND=0
 for FILE in $(find $FOLDER -regex $FILES); do
-    if [ $(wc -L $FILE | cut -d" " -f1) -gt $COLS ] ; then
-        echo -e "\nFound: $FILE"
+    if [ $(wc -L $FILE | cut -d" " -f1) -gt $COLS ]; then
+        [ $FOUND == 0 ] && echo -e "\tError."
+        echo -e "Found: $FILE"
         FOUND=1
     fi
 done


### PR DESCRIPTION
I have resolved an issue with those Travis CI scripts that search for "malformed" files (e.g. containing trailing whitespace). The problem appeared if more than one file was affected. A detailed problem description is provided within the commit messages.