### PR TITLE
Improved Travis CI checks to work with `cargo doc`

### DIFF
--- a/ci/10-trailing_whitespaces.sh
+++ b/ci/10-trailing_whitespaces.sh
@@ -9,9 +9,13 @@ set -o errexit -o nounset
 # Explain what we do
 echo -n ">>> Seaching for lines with trailing whitespaces..."
 
-# Search for trailing whitespaces
+# Check any text file
 FOUND=0
 for FILE in $(find $FOLDER -regex $FILES); do
+    # Ignore files that are ignored by git
+    git check-ignore -q $FILE && continue
+
+    # Search for trailing whitespaces
     if egrep -q " +$" $FILE; then
         [ $FOUND == 0 ] && echo -e "\tError."
         echo -e "Found:\t$FILE"

--- a/ci/20-trailing_newline.sh
+++ b/ci/20-trailing_newline.sh
@@ -9,9 +9,13 @@ set -o errexit -o nounset
 # Explain what we do
 echo -n ">>> Seaching for files without a trailing newline..."
 
-# Search for trailing newline
+# Check any text file
 FOUND=0
 for FILE in $(find $FOLDER -regex $FILES); do
+    # Ignore files that are ignored by git
+    git check-ignore -q $FILE && continue
+
+    # Search for trailing newline
     LASTLINE=$(tail -n 1 $FILE; echo x)
     LASTLINE=${LASTLINE%x}
     if [ "${LASTLINE: -1}" != $'\n' ]; then

--- a/ci/30-line_endings.sh
+++ b/ci/30-line_endings.sh
@@ -9,9 +9,13 @@ set -o errexit -o nounset
 # Explain what we do
 echo -n ">>> Seaching for files with wrong line endings..."
 
-# Search wrong line endings
+# Check any text file
 FOUND=0
 for FILE in $(find $FOLDER -regex $FILES); do
+    # Ignore files that are ignored by git
+    git check-ignore -q $FILE && continue
+
+    # Search wrong line endings
     if grep -q $'\r' $FILE; then
         [ $FOUND == 0 ] && echo -e "\tError."
         echo -e "Found: $FILE"

--- a/ci/40-indentation.sh
+++ b/ci/40-indentation.sh
@@ -9,9 +9,13 @@ set -o errexit -o nounset
 # Explain what we do
 echo -n ">>> Seaching for files with tab characters..."
 
-# Search for files with tab characters
+# Check any text file
 FOUND=0
 for FILE in $(find $FOLDER -regex $FILES); do
+    # Ignore files that are ignored by git
+    git check-ignore -q $FILE && continue
+
+    # Search for files with tab characters
     if grep -q $'\t' $FILE; then
         [ $FOUND == 0 ] && echo -e "\t\tError."
         echo -e "Found: $FILE"

--- a/ci/50-line_length.sh
+++ b/ci/50-line_length.sh
@@ -10,9 +10,13 @@ set -o errexit -o nounset
 # Explain what we do
 echo -n ">>> Seaching for lines exceeding the length limit..."
 
-# Seach for lines that are too long
+# Check any text file
 FOUND=0
 for FILE in $(find $FOLDER -regex $FILES); do
+    # Ignore files that are ignored by git
+    git check-ignore -q $FILE && continue
+
+    # Seach for lines that are too long
     if [ $(wc -L $FILE | cut -d" " -f1) -gt $COLS ]; then
         [ $FOUND == 0 ] && echo -e "\tError."
         echo -e "Found: $FILE"

--- a/ci/80-doc.sh
+++ b/ci/80-doc.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Exit script on first error
+set -o errexit -o nounset
+
+# Explain what we do
+echo ">>> Checking the documentation..."
+
+# Build the project
+export RUSTFLAGS="--deny warnings"
+cargo doc


### PR DESCRIPTION
I was starting to write documentation comments when I realized that our Travis CI scripts have issues with the documentation:

1. Travis CI does not check that our documentation can be generated with `cargo doc`. So I added another test that ensures that.
2. *A larger bug:* If you generate the documentation with `cargo doc`, text files will be written to `target/doc`. Since these files do not fit our styleguides, `ci/run.sh` will fail. I resolved this issue by ignoring files in the stylechecks that are ignored by Git.