### PR TITLE
Memory interface bugfix

### DIFF
--- a/src/machine/state/mem.rs
+++ b/src/machine/state/mem.rs
@@ -2,10 +2,10 @@ use machine::state::types::*;
 
 use std::ops::{Index, IndexMut};
 
-pub struct ByteAt(u64);
-pub struct WydeAt(u64);
-pub struct TetraAt(u64);
-pub struct OctaAt(u64);
+pub struct ByteAt(pub u64);
+pub struct WydeAt(pub u64);
+pub struct TetraAt(pub u64);
+pub struct OctaAt(pub u64);
 
 pub struct Memory(());
 

--- a/src/machine/state/sr.rs
+++ b/src/machine/state/sr.rs
@@ -3,7 +3,7 @@ use machine::state::types::Octa;
 use std::mem::transmute;
 use std::ops::{Index, IndexMut};
 
-enum R {
+pub enum R {
     A = 21,  B =  0,  C =  8,  D =  1,  E =  2,  F = 22,  G = 19,  H =  3,
     I = 12,  J =  4,  K = 15,  L = 20,  M =  5,  N =  9,  O = 10,  P = 23,
     Q = 16,  R =  6,  S = 11,  T = 13,  U = 17,  V = 18,  W = 24,  X = 25,


### PR DESCRIPTION
Fix for issue #9 and #22. Replacing pull-request #23.

The following bugs have been resolved: 
  - The enum R in machine::state::sr must be public.
  - The accessor types in machine::state::mem must have public fields.

(Otherwise, you cannot work with the memory and special registers!)