### PR TITLE
Attempt at implementing Memory (Need help)

### DIFF
--- a/src/machine/state/mem.rs
+++ b/src/machine/state/mem.rs
@@ -1,5 +1,6 @@
 use machine::state::types::*;
 
+use std::mem::transmute;
 use std::ops::{Index, IndexMut};
 
 pub struct ByteAt(pub u64);
@@ -7,37 +8,97 @@ pub struct WydeAt(pub u64);
 pub struct TetraAt(pub u64);
 pub struct OctaAt(pub u64);
 
-pub struct Memory(());
+pub struct Memory(Vec<u8>);
+
+// 2^30
+// TODO let the user choose the size
+const MAX_ADDRESS : usize = 0x40000000;
+
+static ZERO_BYTE : Byte = Byte(0);
+static ZERO_WYDE: Wyde = Wyde(0);
 
 impl Memory {
     pub fn new() -> Self {
-        unimplemented!();
+        Memory(Vec::new())
     }
 }
 
 impl Index<ByteAt> for Memory {
     type Output = Byte;
-    fn index(&self, _: ByteAt) -> &Self::Output {
-        unimplemented!();
+    fn index(&self, index: ByteAt) -> &Self::Output {
+        let i = index.0 as usize;
+        assert!(i < MAX_ADDRESS);
+        println!("{} >= {}?", i, self.0.len());
+        if i >= self.0.len() {
+            &ZERO_BYTE
+        } else {
+            let raw_ref = self.0.get(i).unwrap();
+            unsafe {
+                transmute::<&u8, &Byte>(raw_ref)
+            }
+        }
     }
 }
 
 impl IndexMut<ByteAt> for Memory {
-    fn index_mut(&mut self, _: ByteAt) -> &mut Self::Output {
-        unimplemented!();
+    fn index_mut(&mut self, index: ByteAt) -> &mut Self::Output {
+        let i = index.0 as usize;
+        assert!(i < MAX_ADDRESS);
+        if i >= self.0.len() {
+            // make the new size a multiple of 8, so that no problems arise for
+            // Wydes, Tetras and Octas
+            let new_size = (i | 111) + 1;
+            self.0.resize(new_size, 0);
+        }
+        let raw_ref = self.0.get_mut(i).unwrap();
+        unsafe {
+            transmute::<&mut u8, &mut Byte>(raw_ref)
+        }
     }
 }
 
 impl Index<WydeAt> for Memory {
     type Output = Wyde;
-    fn index(&self, _: WydeAt) -> &Self::Output {
-        unimplemented!();
+    fn index(&self, index: WydeAt) -> &Self::Output {
+
+        let lo = (index.0 | 1) as usize;
+        let hi = lo - 1;
+
+        assert!(lo < MAX_ADDRESS);
+
+        if lo >= self.0.len() {
+            &ZERO_WYDE
+        } else {
+            println!("vector length: {}", self.0.len());
+            println!("requested address: {}", index.0);
+            println!("high byte at index {}: {}", hi, self.0[hi]);
+            println!("low byte at index {}: {}", lo, self.0[lo]);
+            unsafe {
+                transmute::<&(u8, u8), &Wyde>(&(self.0[hi], self.0[lo]))
+
+            }
+        }
+
+
+
     }
 }
 
 impl IndexMut<WydeAt> for Memory {
-    fn index_mut(&mut self, _: WydeAt) -> &mut Self::Output {
-        unimplemented!();
+    fn index_mut(&mut self, index: WydeAt) -> &mut Self::Output {
+
+        let lo = (index.0 | 1) as usize;
+        let hi = lo - 1;
+
+        assert!(lo < MAX_ADDRESS);
+
+        if lo >= self.0.len() {
+            let new_size = (lo | 111) + 1;
+            self.0.resize(new_size, 0);
+        }
+        unsafe {
+            transmute::<&mut (u8, u8), &mut Wyde>(&mut (self.0[hi], self.0[lo]))
+        }
     }
 }
 
@@ -65,4 +126,29 @@ impl IndexMut<OctaAt> for Memory {
     fn index_mut(&mut self, _: OctaAt) -> &mut Self::Output {
         unimplemented!();
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn byte_index() {
+        let mut mem = Memory::new();
+        assert_eq!(mem[ByteAt(0)].0, 0u8);
+        assert_eq!(mem[ByteAt(10)].0, 0u8);
+        mem[ByteAt(100)] = 10u8.into();
+        assert_eq!(mem[ByteAt(100)], 10u8.into());
+    }
+
+    #[test]
+    fn wyde_index() {
+        let mut mem = Memory::new();
+        assert_eq!(mem[WydeAt(12345)].0, 0u16);
+        mem[WydeAt(123)] = 42u16.into();
+        assert_eq!(mem[WydeAt(123)], 42u16.into());
+
+    }
+
+
 }

--- a/src/machine/state/types.rs
+++ b/src/machine/state/types.rs
@@ -1,16 +1,16 @@
 use std::mem::transmute;
 
-#[derive(Clone, Copy)]
-pub struct Byte(u8);
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct Byte(pub u8);
 
-#[derive(Clone, Copy)]
-pub struct Wyde(u16);
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct Wyde(pub u16);
 
-#[derive(Clone, Copy)]
-pub struct Tetra(u32);
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct Tetra(pub u32);
 
-#[derive(Clone, Copy)]
-pub struct Octa(u64);
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct Octa(pub u64);
 
 macro_rules! type_impl {
     ( $( ($outer:ident, $inner:ty) => ($( $convert:ty ),*), )* ) => {


### PR DESCRIPTION
I tried to implement a simple version of the memory, with memory simply wrapping a `Vec<u8>`. For the moment I am disregarding memory mapping etc. I implemented Index for `ByteAt` and `WydeAt`. Indexing using `TetraAt` and `OctaAt` is still unimplemented!().
ByteAt works (according to unit test), but the test for WydeAt fails.

It makes sense to me that this line does not work as intended: 
```
transmute::<&mut (u8, u8), &mut Wyde>(&mut (self.0[hi], self.0[lo]))
```
But this is the only thing of the things that I tried that compiles. I can't transmute a slice, or two references, I can't create  a new array, using `.get(i)` instead of `[i]` doesn't change anything, neither does using raw pointers. Does anybody see a way to achieve the intended functionality?

Could I avoid this problem by storing `u64` rather than `u8` in the vec?