### PR TITLE
implemented all bytewise instructions

### DIFF
--- a/src/machine/behavior/is/bytewise/bdif.rs
+++ b/src/machine/behavior/is/bytewise/bdif.rs
@@ -9,8 +9,8 @@ pub fn bdif(state: &mut State, x: u8, y: u8, z: u8) {
     // Execute
     let mut result: u64 = 0;
     for i in 0..8 {
-        let y_byte = get_byte(op1);
-        let z_byte = get_byte(op2);
+        let y_byte = super::get_byte(op1);
+        let z_byte = super::get_byte(op2);
         let interim = (y_byte.saturating_sub(z_byte) as u64) << (8 * i);
         result += interim;
         op1 >>= 8;
@@ -19,8 +19,4 @@ pub fn bdif(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Store result
     state.gpr[x] = result.into();
-}
-
-fn get_byte(bits: u64) -> u8 {
-    bits as u8
 }

--- a/src/machine/behavior/is/bytewise/bdif.rs
+++ b/src/machine/behavior/is/bytewise/bdif.rs
@@ -1,6 +1,26 @@
 use machine::state::State;
 
-pub fn bdif(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+/// byte difference
+pub fn bdif(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let mut op1: u64 = state.gpr[y].into();
+    let mut op2: u64 = state.gpr[z].into();
+
+    // Execute
+    let mut result: u64 = 0;
+    for i in 0..8 {
+        let y_byte = get_byte(op1);
+        let z_byte = get_byte(op2);
+        let interim = (y_byte.saturating_sub(z_byte) as u64) << (8 * i);
+        result += interim;
+        op1 >>= 8;
+        op2 >>= 8;
+    }
+
+    // Store result
+    state.gpr[x] = result.into();
 }
 
+fn get_byte(bits: u64) -> u8 {
+    bits as u8
+}

--- a/src/machine/behavior/is/bytewise/bdifi.rs
+++ b/src/machine/behavior/is/bytewise/bdifi.rs
@@ -1,6 +1,13 @@
 use machine::state::State;
 
-pub fn bdifi(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+/// byte difference immediate
+pub fn bdifi(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load first operand
+    let op1: u64 = state.gpr[y].into();
 
+    // Execute
+    let result = op1.saturating_sub(z as u64);
+
+    // Store result
+    state.gpr[x] = result.into();
+}

--- a/src/machine/behavior/is/bytewise/bdifi.rs
+++ b/src/machine/behavior/is/bytewise/bdifi.rs
@@ -2,12 +2,5 @@ use machine::state::State;
 
 /// byte difference immediate
 pub fn bdifi(state: &mut State, x: u8, y: u8, z: u8) {
-    // Load first operand
-    let op1: u64 = state.gpr[y].into();
-
-    // Execute
-    let result = op1.saturating_sub(z as u64);
-
-    // Store result
-    state.gpr[x] = result.into();
+    odifi(x, y, z);
 }

--- a/src/machine/behavior/is/bytewise/bdifi.rs
+++ b/src/machine/behavior/is/bytewise/bdifi.rs
@@ -1,7 +1,16 @@
 use machine::state::State;
-use machine::behavior::is::bytewise::odifi;
 
 /// byte difference immediate
 pub fn bdifi(state: &mut State, x: u8, y: u8, z: u8) {
-    odifi(state, x, y, z);
+    // Load first operand
+    let op1: u64 = state.gpr[y].into();
+
+    // Execute
+    let mut result = (op1 >> 8) << 8;
+    let y_byte = super::get_byte(op1);
+    let interim = y_byte.saturating_sub(z) as u64;
+    result += interim;
+
+    // Store result
+    state.gpr[x] = result.into();
 }

--- a/src/machine/behavior/is/bytewise/bdifi.rs
+++ b/src/machine/behavior/is/bytewise/bdifi.rs
@@ -1,6 +1,7 @@
 use machine::state::State;
+use machine::behavior::is::bytewise::odifi;
 
 /// byte difference immediate
 pub fn bdifi(state: &mut State, x: u8, y: u8, z: u8) {
-    odifi(x, y, z);
+    odifi(state, x, y, z);
 }

--- a/src/machine/behavior/is/bytewise/mod.rs
+++ b/src/machine/behavior/is/bytewise/mod.rs
@@ -13,3 +13,17 @@ mod_def_reexport!{
     wdif,
 }
 
+
+fn get_byte(bits: u64) -> u8 {
+    bits as u8
+}
+
+
+fn get_wyde(bits: u64) -> u16 {
+    bits as u16
+}
+
+
+fn get_tetra(bits: u64) -> u32 {
+    bits as u32
+}

--- a/src/machine/behavior/is/bytewise/mod.rs
+++ b/src/machine/behavior/is/bytewise/mod.rs
@@ -13,16 +13,13 @@ mod_def_reexport!{
     wdif,
 }
 
-
 fn get_byte(bits: u64) -> u8 {
     bits as u8
 }
 
-
 fn get_wyde(bits: u64) -> u16 {
     bits as u16
 }
-
 
 fn get_tetra(bits: u64) -> u32 {
     bits as u32

--- a/src/machine/behavior/is/bytewise/mor.rs
+++ b/src/machine/behavior/is/bytewise/mor.rs
@@ -1,6 +1,49 @@
 use machine::state::State;
 
-pub fn mor(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+/// multiple or
+pub fn mor(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let mut op1: u64 = state.gpr[y].into();
+    let mut op2: u64 = state.gpr[z].into();
+
+    // Execute
+    let mut matrix_op1:     [[bool; 8]; 8] = [[false; 8]; 8];
+    let mut matrix_op2:     [[bool; 8]; 8] = [[false; 8]; 8];
+    let mut matrix_result:  [[bool; 8]; 8] = [[false; 8]; 8];
+
+    for i in 0..8 {
+        for j in 0..8 {
+            matrix_op1[7 - i][7 - j] = get_last_bit(op1);
+            matrix_op2[7 - i][7 - j] = get_last_bit(op2);
+            op1 >>= 1;
+            op2 >>= 1;
+        }
+    }
+
+    for i in 0..8 {
+        for j in 0..8 {
+            let mut entry = false;
+            for k in 0..8 {
+                entry = entry | (matrix_op1[i][k] & matrix_op2[k][j]);
+            }
+            matrix_result[i][j] = entry;
+        }
+    }
+
+    let mut result: u64 = 0;
+
+    for i in 0..8 {
+        for j in 0..8 {
+            result <<= 1;
+            result += matrix_result[i][j] as u64;
+
+        }
+    }
+
+    // Store result
+    state.gpr[x] = result.into();
 }
 
+fn get_last_bit(bits: u64) -> bool {
+    bits % 2 != 0
+}

--- a/src/machine/behavior/is/bytewise/mori.rs
+++ b/src/machine/behavior/is/bytewise/mori.rs
@@ -1,6 +1,51 @@
 use machine::state::State;
 
-pub fn mori(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+/// multiple or immediate
+pub fn mori(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load first operand
+    let mut op1: u64 = state.gpr[y].into();
+
+    // Make z mutable
+    let mut z = z;
+
+    // Execute
+    let mut matrix_op1:     [[bool; 8]; 8] = [[false; 8]; 8];
+    let mut matrix_z:       [[bool; 8]; 8] = [[false; 8]; 8];
+    let mut matrix_result:  [[bool; 8]; 8] = [[false; 8]; 8];
+
+    for i in 0..8 {
+        for j in 0..8 {
+            matrix_op1[7 - i][7 - j] = get_last_bit(op1);
+            matrix_z[7 - i][7 - j] = get_last_bit(z as u64);
+            op1 >>= 1;
+            z >>= 1;
+        }
+    }
+
+    for i in 0..8 {
+        for j in 0..8 {
+            let mut entry = false;
+            for k in 0..8 {
+                entry = entry | (matrix_op1[i][k] & matrix_z[k][j]);
+            }
+            matrix_result[i][j] = entry;
+        }
+    }
+
+    let mut result: u64 = 0;
+
+    for i in 0..8 {
+        for j in 0..8 {
+            result <<= 1;
+            result += matrix_result[i][j] as u64;
+
+        }
+    }
+
+    // Store result
+    state.gpr[x] = result.into();
 }
 
+fn get_last_bit(bits: u64) -> bool {
+    bits % 2 != 0
+}

--- a/src/machine/behavior/is/bytewise/mxor.rs
+++ b/src/machine/behavior/is/bytewise/mxor.rs
@@ -1,6 +1,49 @@
 use machine::state::State;
 
-pub fn mxor(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+/// multiple exclusive-or
+pub fn mxor(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let mut op1: u64 = state.gpr[y].into();
+    let mut op2: u64 = state.gpr[z].into();
+
+    // Execute
+    let mut matrix_op1:     [[bool; 8]; 8] = [[false; 8]; 8];
+    let mut matrix_op2:     [[bool; 8]; 8] = [[false; 8]; 8];
+    let mut matrix_result:  [[bool; 8]; 8] = [[false; 8]; 8];
+
+    for i in 0..8 {
+        for j in 0..8 {
+            matrix_op1[7 - i][7 - j] = get_last_bit(op1);
+            matrix_op2[7 - i][7 - j] = get_last_bit(op2);
+            op1 >>= 1;
+            op2 >>= 1;
+        }
+    }
+
+    for i in 0..8 {
+        for j in 0..8 {
+            let mut entry = false;
+            for k in 0..8 {
+                entry = entry ^ (matrix_op1[i][k] & matrix_op2[k][j]);
+            }
+            matrix_result[i][j] = entry;
+        }
+    }
+
+    let mut result: u64 = 0;
+
+    for i in 0..8 {
+        for j in 0..8 {
+            result <<= 1;
+            result += matrix_result[i][j] as u64;
+
+        }
+    }
+
+    // Store result
+    state.gpr[x] = result.into();
 }
 
+fn get_last_bit(bits: u64) -> bool {
+    bits % 2 != 0
+}

--- a/src/machine/behavior/is/bytewise/mxori.rs
+++ b/src/machine/behavior/is/bytewise/mxori.rs
@@ -1,6 +1,51 @@
 use machine::state::State;
 
-pub fn mxori(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+/// multiple exclusive-or immediate
+pub fn mxori(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load first operand
+    let mut op1: u64 = state.gpr[y].into();
+
+    // Make z mutable
+    let mut z = z;
+
+    // Execute
+    let mut matrix_op1:     [[bool; 8]; 8] = [[false; 8]; 8];
+    let mut matrix_z:       [[bool; 8]; 8] = [[false; 8]; 8];
+    let mut matrix_result:  [[bool; 8]; 8] = [[false; 8]; 8];
+
+    for i in 0..8 {
+        for j in 0..8 {
+            matrix_op1[7 - i][7 - j] = get_last_bit(op1);
+            matrix_z[7 - i][7 - j] = get_last_bit(z as u64);
+            op1 >>= 1;
+            z >>= 1;
+        }
+    }
+
+    for i in 0..8 {
+        for j in 0..8 {
+            let mut entry = false;
+            for k in 0..8 {
+                entry = entry ^ (matrix_op1[i][k] & matrix_z[k][j]);
+            }
+            matrix_result[i][j] = entry;
+        }
+    }
+
+    let mut result: u64 = 0;
+
+    for i in 0..8 {
+        for j in 0..8 {
+            result <<= 1;
+            result += matrix_result[i][j] as u64;
+
+        }
+    }
+
+    // Store result
+    state.gpr[x] = result.into();
 }
 
+fn get_last_bit(bits: u64) -> bool {
+    bits % 2 != 0
+}

--- a/src/machine/behavior/is/bytewise/odif.rs
+++ b/src/machine/behavior/is/bytewise/odif.rs
@@ -1,6 +1,14 @@
 use machine::state::State;
 
-pub fn odif(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+/// octa difference
+pub fn odif(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: u64 = state.gpr[y].into();
+    let op2: u64 = state.gpr[z].into();
 
+    // Execute
+    let result = op1.saturating_sub(op2);
+
+    // Store result
+    state.gpr[x] = result.into();
+}

--- a/src/machine/behavior/is/bytewise/odifi.rs
+++ b/src/machine/behavior/is/bytewise/odifi.rs
@@ -1,6 +1,13 @@
 use machine::state::State;
 
-pub fn odifi(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+/// octa difference immediate
+pub fn odifi(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load first operand
+    let op1: u64 = state.gpr[y].into();
 
+    // Execute
+    let result = op1.saturating_sub(z as u64);
+
+    // Store result
+    state.gpr[x] = result.into();
+}

--- a/src/machine/behavior/is/bytewise/tdif.rs
+++ b/src/machine/behavior/is/bytewise/tdif.rs
@@ -1,6 +1,26 @@
 use machine::state::State;
 
-pub fn tdif(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+/// tetra difference
+pub fn tdif(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let mut op1: u64 = state.gpr[y].into();
+    let mut op2: u64 = state.gpr[z].into();
+
+    // Execute
+    let mut result: u64 = 0;
+    for i in 0..2 {
+        let y_tetra = get_tetra(op1);
+        let z_tetra = get_tetra(op2);
+        let interim = (y_tetra.saturating_sub(z_tetra) as u64) << (32 * i);
+        result += interim;
+        op1 >>= 32;
+        op2 >>= 32;
+    }
+
+    // Store result
+    state.gpr[x] = result.into();
 }
 
+fn get_tetra(bits: u64) -> u32 {
+    bits as u32
+}

--- a/src/machine/behavior/is/bytewise/tdif.rs
+++ b/src/machine/behavior/is/bytewise/tdif.rs
@@ -9,8 +9,8 @@ pub fn tdif(state: &mut State, x: u8, y: u8, z: u8) {
     // Execute
     let mut result: u64 = 0;
     for i in 0..2 {
-        let y_tetra = get_tetra(op1);
-        let z_tetra = get_tetra(op2);
+        let y_tetra = super::get_tetra(op1);
+        let z_tetra = super::get_tetra(op2);
         let interim = (y_tetra.saturating_sub(z_tetra) as u64) << (32 * i);
         result += interim;
         op1 >>= 32;
@@ -19,8 +19,4 @@ pub fn tdif(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Store result
     state.gpr[x] = result.into();
-}
-
-fn get_tetra(bits: u64) -> u32 {
-    bits as u32
 }

--- a/src/machine/behavior/is/bytewise/tdifi.rs
+++ b/src/machine/behavior/is/bytewise/tdifi.rs
@@ -2,12 +2,5 @@ use machine::state::State;
 
 /// tetra difference immediate
 pub fn tdifi(state: &mut State, x: u8, y: u8, z: u8) {
-   // Load first operand
-    let op1: u64 = state.gpr[y].into();
-
-    // Execute
-    let result = op1.saturating_sub(z as u64);
-
-    // Store result
-    state.gpr[x] = result.into();
+   odifi(x, y, z);
 }

--- a/src/machine/behavior/is/bytewise/tdifi.rs
+++ b/src/machine/behavior/is/bytewise/tdifi.rs
@@ -1,7 +1,16 @@
 use machine::state::State;
-use machine::behavior::is::bytewise::odifi;
 
 /// tetra difference immediate
 pub fn tdifi(state: &mut State, x: u8, y: u8, z: u8) {
-    odifi(state, x, y, z);
+    // Load first operand
+    let op1: u64 = state.gpr[y].into();
+
+    // Execute
+    let mut result = (op1 >> 32) << 32;
+    let y_tetra = super::get_tetra(op1);
+    let interim = y_tetra.saturating_sub(z as u32) as u64;
+    result += interim;
+
+    // Store result
+    state.gpr[x] = result.into();
 }

--- a/src/machine/behavior/is/bytewise/tdifi.rs
+++ b/src/machine/behavior/is/bytewise/tdifi.rs
@@ -1,6 +1,13 @@
 use machine::state::State;
 
-pub fn tdifi(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+/// tetra difference immediate
+pub fn tdifi(state: &mut State, x: u8, y: u8, z: u8) {
+   // Load first operand
+    let op1: u64 = state.gpr[y].into();
 
+    // Execute
+    let result = op1.saturating_sub(z as u64);
+
+    // Store result
+    state.gpr[x] = result.into();
+}

--- a/src/machine/behavior/is/bytewise/tdifi.rs
+++ b/src/machine/behavior/is/bytewise/tdifi.rs
@@ -1,6 +1,7 @@
 use machine::state::State;
+use machine::behavior::is::bytewise::odifi;
 
 /// tetra difference immediate
 pub fn tdifi(state: &mut State, x: u8, y: u8, z: u8) {
-   odifi(x, y, z);
+    odifi(state, x, y, z);
 }

--- a/src/machine/behavior/is/bytewise/wdif.rs
+++ b/src/machine/behavior/is/bytewise/wdif.rs
@@ -9,8 +9,8 @@ pub fn wdif(state: &mut State, x: u8, y: u8, z: u8) {
     // Execute
     let mut result: u64 = 0;
     for i in 0..4 {
-        let y_wyde = get_wyde(op1);
-        let z_wyde = get_wyde(op2);
+        let y_wyde = super::get_wyde(op1);
+        let z_wyde = super::get_wyde(op2);
         let interim = (y_wyde.saturating_sub(z_wyde) as u64) << (16 * i);
         result += interim;
         op1 >>= 16;
@@ -19,8 +19,4 @@ pub fn wdif(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Store result
     state.gpr[x] = result.into();
-}
-
-fn get_wyde(bits: u64) -> u16 {
-    bits as u16
 }

--- a/src/machine/behavior/is/bytewise/wdif.rs
+++ b/src/machine/behavior/is/bytewise/wdif.rs
@@ -1,6 +1,26 @@
 use machine::state::State;
 
-pub fn wdif(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+/// wyde difference
+pub fn wdif(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let mut op1: u64 = state.gpr[y].into();
+    let mut op2: u64 = state.gpr[z].into();
+
+    // Execute
+    let mut result: u64 = 0;
+    for i in 0..4 {
+        let y_wyde = get_wyde(op1);
+        let z_wyde = get_wyde(op2);
+        let interim = (y_wyde.saturating_sub(z_wyde) as u64) << (16 * i);
+        result += interim;
+        op1 >>= 16;
+        op2 >>= 16;
+    }
+
+    // Store result
+    state.gpr[x] = result.into();
 }
 
+fn get_wyde(bits: u64) -> u16 {
+    bits as u16
+}

--- a/src/machine/behavior/is/bytewise/wdifi.rs
+++ b/src/machine/behavior/is/bytewise/wdifi.rs
@@ -1,6 +1,13 @@
 use machine::state::State;
 
-pub fn wdifi(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+/// wyde difference immediate
+pub fn wdifi(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load first operand
+    let op1: u64 = state.gpr[y].into();
 
+    // Execute
+    let result = op1.saturating_sub(z as u64);
+
+    // Store result
+    state.gpr[x] = result.into();
+}

--- a/src/machine/behavior/is/bytewise/wdifi.rs
+++ b/src/machine/behavior/is/bytewise/wdifi.rs
@@ -2,12 +2,5 @@ use machine::state::State;
 
 /// wyde difference immediate
 pub fn wdifi(state: &mut State, x: u8, y: u8, z: u8) {
-    // Load first operand
-    let op1: u64 = state.gpr[y].into();
-
-    // Execute
-    let result = op1.saturating_sub(z as u64);
-
-    // Store result
-    state.gpr[x] = result.into();
+    odifi(x, y, z);
 }

--- a/src/machine/behavior/is/bytewise/wdifi.rs
+++ b/src/machine/behavior/is/bytewise/wdifi.rs
@@ -1,7 +1,16 @@
 use machine::state::State;
-use machine::behavior::is::bytewise::odifi;
 
 /// wyde difference immediate
 pub fn wdifi(state: &mut State, x: u8, y: u8, z: u8) {
-    odifi(state, x, y, z);
+    // Load first operand
+    let op1: u64 = state.gpr[y].into();
+
+    // Execute
+    let mut result = (op1 >> 16) << 16;
+    let y_wyde = super::get_wyde(op1);
+    let interim = y_wyde.saturating_sub(z as u16) as u64;
+    result += interim;
+
+    // Store result
+    state.gpr[x] = result.into();
 }

--- a/src/machine/behavior/is/bytewise/wdifi.rs
+++ b/src/machine/behavior/is/bytewise/wdifi.rs
@@ -1,6 +1,7 @@
 use machine::state::State;
+use machine::behavior::is::bytewise::odifi;
 
 /// wyde difference immediate
 pub fn wdifi(state: &mut State, x: u8, y: u8, z: u8) {
-    odifi(x, y, z);
+    odifi(state, x, y, z);
 }


### PR DESCRIPTION
Known issues: 
- duplicate code (especially in mor[i], mxor[i])
-> Again, the only (possibly) feasible alternative would be to put several instructions in the same 
     file.
~~- not sure if bdifi, wdifi, tdifi, odifi are correctly implemented (see my question under issue #5 )
   If they are correctly implemented, it might be better replace three of the implementations with 
   instruction calls to the fourth one. (If we want to allow such instruction calls.)~~
**bdifi, wdifi, tdifi are fixed**
- sparsely commented