### PR TITLE
Implemented most float instructions

### DIFF
--- a/src/machine/behavior/is/float/fadd.rs
+++ b/src/machine/behavior/is/float/fadd.rs
@@ -1,6 +1,13 @@
 use machine::state::State;
 
-pub fn fadd(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+pub fn fadd(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: f64 = state.gpr[y].into();
+    let op2: f64 = state.gpr[z].into();
 
+    // Execute
+    let res = op1 + op2;
+
+    // Store result
+    state.gpr[x] = res.into();
+}

--- a/src/machine/behavior/is/float/fcmp.rs
+++ b/src/machine/behavior/is/float/fcmp.rs
@@ -5,13 +5,13 @@ pub fn fcmp(state: &mut State, x: u8, y: u8, z: u8) {
     let op1: f64 = state.gpr[y].into();
     let op2: f64 = state.gpr[z].into();
 
-    // Execute and store result
-    if op1 - op2 > 0.0 {
-        state.gpr[x] = 1i64.into();
-    } else if op1 - op2 < 0.0 {
-        state.gpr[x] = (-1 as i64).into();
-    } else {
-        state.gpr[x] = 0i64.into();
-    }
+    // Execute
+    let res: i64 = match op1 - op2 {
+        d if d > 0.0 =>  1,
+        d if d < 0.0 => -1,
+        _            =>  0,
+    };
 
+    // Store result
+    state.gpr[x] = res.into();
 }

--- a/src/machine/behavior/is/float/fcmp.rs
+++ b/src/machine/behavior/is/float/fcmp.rs
@@ -1,6 +1,17 @@
 use machine::state::State;
 
-pub fn fcmp(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+pub fn fcmp(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: f64 = state.gpr[y].into();
+    let op2: f64 = state.gpr[z].into();
 
+    // Execute and store result
+    if op1 - op2 > 0.0 {
+    	state.gpr[x] = 1i64.into();
+    } else if op1 - op2 < 0.0 {
+    	state.gpr[x] = (-1 as i64).into();
+    } else {
+    	state.gpr[x] = 0i64.into();
+    }
+
+}

--- a/src/machine/behavior/is/float/fcmp.rs
+++ b/src/machine/behavior/is/float/fcmp.rs
@@ -7,11 +7,11 @@ pub fn fcmp(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Execute and store result
     if op1 - op2 > 0.0 {
-    	state.gpr[x] = 1i64.into();
+        state.gpr[x] = 1i64.into();
     } else if op1 - op2 < 0.0 {
-    	state.gpr[x] = (-1 as i64).into();
+        state.gpr[x] = (-1 as i64).into();
     } else {
-    	state.gpr[x] = 0i64.into();
+        state.gpr[x] = 0i64.into();
     }
 
 }

--- a/src/machine/behavior/is/float/fcmpe.rs
+++ b/src/machine/behavior/is/float/fcmpe.rs
@@ -3,9 +3,9 @@ use machine::state::sr::R;
 
 pub fn fcmpe(state: &mut State, x: u8, y: u8, z: u8) {
     // Load operands
-    let op1: u64 = state.gpr[y].into();
-    let op2: u64 = state.gpr[z].into();
-    let eps: u64 = state.sr[R::E].into();
+    let op1: f64 = state.gpr[y].into();
+    let op2: f64 = state.gpr[z].into();
+    let eps: f64 = state.sr[R::E].into();
 
     // Execute
     let res = ((op1 as i64).wrapping_sub(op2 as i64)).abs();

--- a/src/machine/behavior/is/float/fcmpe.rs
+++ b/src/machine/behavior/is/float/fcmpe.rs
@@ -1,6 +1,21 @@
 use machine::state::State;
+use machine::state::sr::R;
 
-pub fn fcmpe(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+pub fn fcmpe(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: u64 = state.gpr[y].into();
+    let op2: u64 = state.gpr[z].into();
+    let eps: u64 = state.sr[R::E].into();
+
+    // Execute
+    let res = ((op1 as i64).wrapping_sub(op2 as i64)).abs();
+
+    // Store result
+    if res <= eps as i64 {
+    	state.gpr[x] = 0i64.into();
+    } else if op1 > op2 {
+    	state.gpr[x] = 1i64.into();
+    } else {
+    	state.gpr[x] = (-1 as i64).into();
+    }
 }
-

--- a/src/machine/behavior/is/float/fcmpe.rs
+++ b/src/machine/behavior/is/float/fcmpe.rs
@@ -12,10 +12,10 @@ pub fn fcmpe(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Store result
     if res <= eps as i64 {
-    	state.gpr[x] = 0i64.into();
+        state.gpr[x] = 0i64.into();
     } else if op1 > op2 {
-    	state.gpr[x] = 1i64.into();
+        state.gpr[x] = 1i64.into();
     } else {
-    	state.gpr[x] = (-1 as i64).into();
+        state.gpr[x] = (-1 as i64).into();
     }
 }

--- a/src/machine/behavior/is/float/fcmpe.rs
+++ b/src/machine/behavior/is/float/fcmpe.rs
@@ -11,7 +11,7 @@ pub fn fcmpe(state: &mut State, x: u8, y: u8, z: u8) {
     let res: i64 = match op1 - op2 {
         d if d.abs() <= eps =>  0,
         d if d > 0.0        =>  1,
-        _                   => -1, 
+        _                   => -1,
     };
 
     // Store result

--- a/src/machine/behavior/is/float/fcmpe.rs
+++ b/src/machine/behavior/is/float/fcmpe.rs
@@ -8,14 +8,12 @@ pub fn fcmpe(state: &mut State, x: u8, y: u8, z: u8) {
     let eps: f64 = state.sr[R::E].into();
 
     // Execute
-    let res = ((op1 as i64).wrapping_sub(op2 as i64)).abs();
+    let res: i64 = match op1 - op2 {
+        d if d.abs() <= eps =>  0,
+        d if d > 0.0        =>  1,
+        _                   => -1, 
+    };
 
     // Store result
-    if res <= eps as i64 {
-        state.gpr[x] = 0i64.into();
-    } else if op1 > op2 {
-        state.gpr[x] = 1i64.into();
-    } else {
-        state.gpr[x] = (-1 as i64).into();
-    }
+    state.gpr[x] = res.into();
 }

--- a/src/machine/behavior/is/float/fdiv.rs
+++ b/src/machine/behavior/is/float/fdiv.rs
@@ -1,6 +1,13 @@
 use machine::state::State;
 
-pub fn fdiv(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+pub fn fdiv(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: f64 = state.gpr[y].into();
+    let op2: f64 = state.gpr[z].into();
 
+    // Execute
+    let res = op1 / op2;
+
+    // Store result
+    state.gpr[x] = res.into();
+}

--- a/src/machine/behavior/is/float/feql.rs
+++ b/src/machine/behavior/is/float/feql.rs
@@ -7,8 +7,8 @@ pub fn feql(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Execute and store result
     if op1 - op2 == 0.0 {
-    	state.gpr[x] = 1i64.into();
+        state.gpr[x] = 1i64.into();
     } else {
-    	state.gpr[x] = 0i64.into();
+        state.gpr[x] = 0i64.into();
     }
 }

--- a/src/machine/behavior/is/float/feql.rs
+++ b/src/machine/behavior/is/float/feql.rs
@@ -5,10 +5,9 @@ pub fn feql(state: &mut State, x: u8, y: u8, z: u8) {
     let op1: f64 = state.gpr[y].into();
     let op2: f64 = state.gpr[z].into();
 
-    // Execute and store result
-    if op1 - op2 == 0.0 {
-        state.gpr[x] = 1i64.into();
-    } else {
-        state.gpr[x] = 0i64.into();
-    }
+    // Execute
+    let res = (op1 == op2) as i64;
+
+    // Store result
+    state.gpr[x] = res.into();
 }

--- a/src/machine/behavior/is/float/feql.rs
+++ b/src/machine/behavior/is/float/feql.rs
@@ -1,6 +1,14 @@
 use machine::state::State;
 
-pub fn feql(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+pub fn feql(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: f64 = state.gpr[y].into();
+    let op2: f64 = state.gpr[z].into();
 
+    // Execute and store result
+    if op1 - op2 == 0.0 {
+    	state.gpr[x] = 1i64.into();
+    } else {
+    	state.gpr[x] = 0i64.into();
+    }
+}

--- a/src/machine/behavior/is/float/feqle.rs
+++ b/src/machine/behavior/is/float/feqle.rs
@@ -8,12 +8,9 @@ pub fn feqle(state: &mut State, x: u8, y: u8, z: u8) {
     let eps: f64 = state.sr[R::E].into();
 
     // Execute
-    let res = ((op1 as i64).wrapping_sub(op2 as i64)).abs();
+    let gap = (op1 - op2).abs();
+    let res = (gap <= eps) as i64;
 
     // Store result
-    if res <= eps as i64 {
-        state.gpr[x] = 1u64.into();
-    } else {
-        state.gpr[x] = 0u64.into();
-    }
+    state.gpr[x] = res.into();
 }

--- a/src/machine/behavior/is/float/feqle.rs
+++ b/src/machine/behavior/is/float/feqle.rs
@@ -12,8 +12,8 @@ pub fn feqle(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Store result
     if res <= eps as i64 {
-    	state.gpr[x] = 1u64.into();
+        state.gpr[x] = 1u64.into();
     } else {
-    	state.gpr[x] = 0u64.into();
+        state.gpr[x] = 0u64.into();
     }
 }

--- a/src/machine/behavior/is/float/feqle.rs
+++ b/src/machine/behavior/is/float/feqle.rs
@@ -1,6 +1,19 @@
 use machine::state::State;
+use machine::state::sr::R;
 
-pub fn feqle(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+pub fn feqle(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: u64 = state.gpr[y].into();
+    let op2: u64 = state.gpr[z].into();
+    let eps: u64 = state.sr[R::E].into();
+
+    // Execute
+    let res = ((op1 as i64).wrapping_sub(op2 as i64)).abs();
+
+    // Store result
+    if res <= eps as i64 {
+    	state.gpr[x] = 1u64.into();
+    } else {
+    	state.gpr[x] = 0u64.into();
+    }
 }
-

--- a/src/machine/behavior/is/float/feqle.rs
+++ b/src/machine/behavior/is/float/feqle.rs
@@ -3,9 +3,9 @@ use machine::state::sr::R;
 
 pub fn feqle(state: &mut State, x: u8, y: u8, z: u8) {
     // Load operands
-    let op1: u64 = state.gpr[y].into();
-    let op2: u64 = state.gpr[z].into();
-    let eps: u64 = state.sr[R::E].into();
+    let op1: f64 = state.gpr[y].into();
+    let op2: f64 = state.gpr[z].into();
+    let eps: f64 = state.sr[R::E].into();
 
     // Execute
     let res = ((op1 as i64).wrapping_sub(op2 as i64)).abs();

--- a/src/machine/behavior/is/float/fint.rs
+++ b/src/machine/behavior/is/float/fint.rs
@@ -9,7 +9,8 @@ pub fn fint(state: &mut State, x: u8, y: u8, z: u8) {
         1 => op1.round(),    // round off
         2 => op1.ceil(),     // round up
         3 => op1.floor(),    // round down
-        4 => ((op1 + 5.0) / 10.0).floor() * 10.0,        _ => op1.round(),    // round off
+        4 => ((op1 + 5.0) / 10.0).floor() * 10.0,
+        _ => panic!("no rounding mode"),
     };
 
     // Store result

--- a/src/machine/behavior/is/float/fint.rs
+++ b/src/machine/behavior/is/float/fint.rs
@@ -7,14 +7,14 @@ pub fn fint(state: &mut State, x: u8, y: u8, z: u8) {
     // Execute
     let mut res: f64;
     match y {
-    	1 => res = op1.round(),    // round off
-    	2 => res = op1.ceil(),     // round up
-    	3 => res = op1.floor(),    // round down
-    	4 => {                     // round near to ten
+        1 => res = op1.round(),    // round off
+        2 => res = op1.ceil(),     // round up
+        3 => res = op1.floor(),    // round down
+        4 => {                     // round near to ten
             res = (op1 + 5.0) / 10.0;
             res = res.floor() * 10.0;
         },
-    	_ => res = op1.round(),    // round off
+        _ => res = op1.round(),    // round off
     }
 
     // Store result

--- a/src/machine/behavior/is/float/fint.rs
+++ b/src/machine/behavior/is/float/fint.rs
@@ -1,6 +1,22 @@
 use machine::state::State;
 
-pub fn fint(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+pub fn fint(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: f64 = state.gpr[z].into();
 
+    // Execute
+    let mut res: f64;
+    match y {
+    	1 => res = op1.round(),    // round off
+    	2 => res = op1.ceil(),     // round up
+    	3 => res = op1.floor(),    // round down
+    	4 => {                     // round near to ten
+            res = (op1 + 5.0) / 10.0;
+            res = res.floor() * 10.0;
+        },
+    	_ => res = op1.round(),    // round off
+    }
+
+    // Store result
+    state.gpr[x] = res.into();
+}

--- a/src/machine/behavior/is/float/fint.rs
+++ b/src/machine/behavior/is/float/fint.rs
@@ -5,17 +5,12 @@ pub fn fint(state: &mut State, x: u8, y: u8, z: u8) {
     let op1: f64 = state.gpr[z].into();
 
     // Execute
-    let mut res: f64;
-    match y {
-        1 => res = op1.round(),    // round off
-        2 => res = op1.ceil(),     // round up
-        3 => res = op1.floor(),    // round down
-        4 => {                     // round near to ten
-            res = (op1 + 5.0) / 10.0;
-            res = res.floor() * 10.0;
-        },
-        _ => res = op1.round(),    // round off
-    }
+    let res: f64 = match y {
+        1 => op1.round(),    // round off
+        2 => op1.ceil(),     // round up
+        3 => op1.floor(),    // round down
+        4 => ((op1 + 5.0) / 10.0).floor() * 10.0,        _ => op1.round(),    // round off
+    };
 
     // Store result
     state.gpr[x] = res.into();

--- a/src/machine/behavior/is/float/fint.rs
+++ b/src/machine/behavior/is/float/fint.rs
@@ -9,7 +9,7 @@ pub fn fint(state: &mut State, x: u8, y: u8, z: u8) {
         1 => op1.round(),    // round off
         2 => op1.ceil(),     // round up
         3 => op1.floor(),    // round down
-        4 => ((op1 + 5.0) / 10.0).floor() * 10.0,
+        4 => (op1 / 10).ceil() * 10,    // round to nearest ten
         _ => panic!("no rounding mode"),
     };
 

--- a/src/machine/behavior/is/float/fint.rs
+++ b/src/machine/behavior/is/float/fint.rs
@@ -9,7 +9,7 @@ pub fn fint(state: &mut State, x: u8, y: u8, z: u8) {
         1 => op1.round(),    // round off
         2 => op1.ceil(),     // round up
         3 => op1.floor(),    // round down
-        4 => (op1 / 10).ceil() * 10,    // round to nearest ten
+        4 => (op1 / 10.0).ceil() * 10.0,    // round to nearest ten
         _ => panic!("no rounding mode"),
     };
 

--- a/src/machine/behavior/is/float/fix.rs
+++ b/src/machine/behavior/is/float/fix.rs
@@ -1,6 +1,22 @@
 use machine::state::State;
 
-pub fn fix(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+pub fn fix(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: f64 = state.gpr[z].into();
 
+    // Execute
+    let mut res: f64;
+    match y {
+        1 => res = op1.round(),    // round off
+        2 => res = op1.ceil(),     // round up
+        3 => res = op1.floor(),    // round down
+        4 => {                     // round near to ten
+            res = (op1 + 5.0) / 10.0;
+            res = res.floor() * 10.0;
+        },
+        _ => res = op1.round(),    // round off
+    }
+
+    // Store result
+    state.gpr[x] = (res as i64).into();
+}

--- a/src/machine/behavior/is/float/fix.rs
+++ b/src/machine/behavior/is/float/fix.rs
@@ -1,22 +1,6 @@
 use machine::state::State;
 
-pub fn fix(state: &mut State, x: u8, y: u8, z: u8) {
-    // Load operands
-    let op1: f64 = state.gpr[z].into();
-
-    // Execute
-    let mut res: f64;
-    match y {
-        1 => res = op1.round(),    // round off
-        2 => res = op1.ceil(),     // round up
-        3 => res = op1.floor(),    // round down
-        4 => {                     // round near to ten
-            res = (op1 + 5.0) / 10.0;
-            res = res.floor() * 10.0;
-        },
-        _ => res = op1.round(),    // round off
-    }
-
-    // Store result
-    state.gpr[x] = (res as i64).into();
+pub fn fix(_state: &mut State, _x: u8, _y: u8, _z: u8) {
+    unimplemented!();
 }
+

--- a/src/machine/behavior/is/float/fixu.rs
+++ b/src/machine/behavior/is/float/fixu.rs
@@ -1,6 +1,23 @@
 use machine::state::State;
 
-pub fn fixu(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+pub fn fixu(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: f64 = state.gpr[z].into();
+
+    // Execute
+    let mut res: f64;
+    match y {
+        1 => res = op1.round(),    // round off
+        2 => res = op1.ceil(),     // round up
+        3 => res = op1.floor(),    // round down
+        4 => {                     // round near to ten
+            res = (op1 + 5.0) / 10.0;
+            res = res.floor() * 10.0;
+        },
+        _ => res = op1.round(),    // round off
+    }
+
+    // Store result
+    state.gpr[x] = (res.abs() as u64).into();
 }
 

--- a/src/machine/behavior/is/float/fixu.rs
+++ b/src/machine/behavior/is/float/fixu.rs
@@ -1,23 +1,6 @@
 use machine::state::State;
 
-pub fn fixu(state: &mut State, x: u8, y: u8, z: u8) {
-    // Load operands
-    let op1: f64 = state.gpr[z].into();
-
-    // Execute
-    let mut res: f64;
-    match y {
-        1 => res = op1.round(),    // round off
-        2 => res = op1.ceil(),     // round up
-        3 => res = op1.floor(),    // round down
-        4 => {                     // round near to ten
-            res = (op1 + 5.0) / 10.0;
-            res = res.floor() * 10.0;
-        },
-        _ => res = op1.round(),    // round off
-    }
-
-    // Store result
-    state.gpr[x] = (res.abs() as u64).into();
+pub fn fixu(_state: &mut State, _x: u8, _y: u8, _z: u8) {
+    unimplemented!();
 }
 

--- a/src/machine/behavior/is/float/flot.rs
+++ b/src/machine/behavior/is/float/flot.rs
@@ -1,6 +1,19 @@
 use machine::state::State;
 
-pub fn flot(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+pub fn flot(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operand
+    let op1: i64 = state.gpr[z].into();
 
+    // Execute
+    let mut res = op1 as f64;
+    match y {
+    	1 => unimplemented!(),
+    	2 => unimplemented!(),
+    	3 => unimplemented!(),
+    	4 => unimplemented!(),
+    	_ => res = res,
+    }
+
+    // Store result
+    state.gpr[x] = res.into();
+}

--- a/src/machine/behavior/is/float/flot.rs
+++ b/src/machine/behavior/is/float/flot.rs
@@ -7,11 +7,11 @@ pub fn flot(state: &mut State, x: u8, y: u8, z: u8) {
     // Execute
     let mut res = op1 as f64;
     match y {
-    	1 => unimplemented!(),
-    	2 => unimplemented!(),
-    	3 => unimplemented!(),
-    	4 => unimplemented!(),
-    	_ => res = res,
+        1 => unimplemented!(),
+        2 => unimplemented!(),
+        3 => unimplemented!(),
+        4 => unimplemented!(),
+        _ => res = res,
     }
 
     // Store result

--- a/src/machine/behavior/is/float/flot.rs
+++ b/src/machine/behavior/is/float/flot.rs
@@ -6,7 +6,7 @@ pub fn flot(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Execute
     let mut res = op1 as f64;
-    match y {
+    match y {   // FIXME this might be incorrect
         1 => unimplemented!(),
         2 => unimplemented!(),
         3 => unimplemented!(),

--- a/src/machine/behavior/is/float/floti.rs
+++ b/src/machine/behavior/is/float/floti.rs
@@ -7,11 +7,11 @@ pub fn floti(state: &mut State, x: u8, y: u8, z: u8) {
     // Execute
     let mut res = op1 as f64;
     match y {
-    	1 => unimplemented!(),
-    	2 => unimplemented!(),
-    	3 => unimplemented!(),
-    	4 => unimplemented!(),
-    	_ => res = res,
+        1 => unimplemented!(),
+        2 => unimplemented!(),
+        3 => unimplemented!(),
+        4 => unimplemented!(),
+        _ => res = res,
     }
 
     // Store result

--- a/src/machine/behavior/is/float/floti.rs
+++ b/src/machine/behavior/is/float/floti.rs
@@ -1,6 +1,19 @@
 use machine::state::State;
 
-pub fn floti(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+pub fn floti(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operand
+    let op1: i64 = z as i64;
 
+    // Execute
+    let mut res = op1 as f64;
+    match y {
+    	1 => unimplemented!(),
+    	2 => unimplemented!(),
+    	3 => unimplemented!(),
+    	4 => unimplemented!(),
+    	_ => res = res,
+    }
+
+    // Store result
+    state.gpr[x] = res.into();
+}

--- a/src/machine/behavior/is/float/floti.rs
+++ b/src/machine/behavior/is/float/floti.rs
@@ -6,7 +6,7 @@ pub fn floti(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Execute
     let mut res = op1 as f64;
-    match y {
+    match y {   // FIXME this might be incorrect
         1 => unimplemented!(),
         2 => unimplemented!(),
         3 => unimplemented!(),

--- a/src/machine/behavior/is/float/flotu.rs
+++ b/src/machine/behavior/is/float/flotu.rs
@@ -7,11 +7,11 @@ pub fn flotu(state: &mut State, x: u8, y: u8, z: u8) {
     // Execute
     let mut res = op1 as f64;
     match y {
-    	1 => unimplemented!(),
-    	2 => unimplemented!(),
-    	3 => unimplemented!(),
-    	4 => unimplemented!(),
-    	_ => res = res,
+        1 => unimplemented!(),
+        2 => unimplemented!(),
+        3 => unimplemented!(),
+        4 => unimplemented!(),
+        _ => res = res,
     }
 
     // Store result

--- a/src/machine/behavior/is/float/flotu.rs
+++ b/src/machine/behavior/is/float/flotu.rs
@@ -1,6 +1,19 @@
 use machine::state::State;
 
-pub fn flotu(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+pub fn flotu(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operand
+    let op1: u64 = state.gpr[z].into();
 
+    // Execute
+    let mut res = op1 as f64;
+    match y {
+    	1 => unimplemented!(),
+    	2 => unimplemented!(),
+    	3 => unimplemented!(),
+    	4 => unimplemented!(),
+    	_ => res = res,
+    }
+
+    // Store result
+    state.gpr[x] = res.into();
+}

--- a/src/machine/behavior/is/float/flotu.rs
+++ b/src/machine/behavior/is/float/flotu.rs
@@ -6,7 +6,7 @@ pub fn flotu(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Execute
     let mut res = op1 as f64;
-    match y {
+    match y {   // FIXME this might be incorrect
         1 => unimplemented!(),
         2 => unimplemented!(),
         3 => unimplemented!(),

--- a/src/machine/behavior/is/float/flotui.rs
+++ b/src/machine/behavior/is/float/flotui.rs
@@ -1,6 +1,20 @@
 use machine::state::State;
 
-pub fn flotui(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+pub fn flotui(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operand
+    let op1: u64 = z as u64;
+
+    // Execute
+    let mut res = op1 as f64;
+    match y {
+    	1 => unimplemented!(),
+    	2 => unimplemented!(),
+    	3 => unimplemented!(),
+    	4 => unimplemented!(),
+    	_ => res = res,
+    }
+
+    // Store result
+    state.gpr[x] = res.into();
 }
 

--- a/src/machine/behavior/is/float/flotui.rs
+++ b/src/machine/behavior/is/float/flotui.rs
@@ -7,11 +7,11 @@ pub fn flotui(state: &mut State, x: u8, y: u8, z: u8) {
     // Execute
     let mut res = op1 as f64;
     match y {
-    	1 => unimplemented!(),
-    	2 => unimplemented!(),
-    	3 => unimplemented!(),
-    	4 => unimplemented!(),
-    	_ => res = res,
+        1 => unimplemented!(),
+        2 => unimplemented!(),
+        3 => unimplemented!(),
+        4 => unimplemented!(),
+        _ => res = res,
     }
 
     // Store result

--- a/src/machine/behavior/is/float/flotui.rs
+++ b/src/machine/behavior/is/float/flotui.rs
@@ -6,7 +6,7 @@ pub fn flotui(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Execute
     let mut res = op1 as f64;
-    match y {
+    match y {   // FIXME this might be incorrect
         1 => unimplemented!(),
         2 => unimplemented!(),
         3 => unimplemented!(),
@@ -17,4 +17,3 @@ pub fn flotui(state: &mut State, x: u8, y: u8, z: u8) {
     // Store result
     state.gpr[x] = res.into();
 }
-

--- a/src/machine/behavior/is/float/fmul.rs
+++ b/src/machine/behavior/is/float/fmul.rs
@@ -1,6 +1,13 @@
 use machine::state::State;
 
-pub fn fmul(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+pub fn fmul(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: f64 = state.gpr[y].into();
+    let op2: f64 = state.gpr[z].into();
 
+    // Execute
+    let res = op1 * op2;
+
+    // Store result
+    state.gpr[x] = res.into();
+}

--- a/src/machine/behavior/is/float/frem.rs
+++ b/src/machine/behavior/is/float/frem.rs
@@ -1,6 +1,13 @@
 use machine::state::State;
 
-pub fn frem(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+pub fn frem(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: f64 = state.gpr[y].into();
+    let op2: f64 = state.gpr[z].into();
 
+    // Execute
+    let res = op1 % op2;
+
+    // Store result
+    state.gpr[x] = res.into();
+}

--- a/src/machine/behavior/is/float/fsqrt.rs
+++ b/src/machine/behavior/is/float/fsqrt.rs
@@ -5,15 +5,12 @@ pub fn fsqrt(state: &mut State, x: u8, y: u8, z: u8) {
     let op1: f64 = state.gpr[z].into();
 
     // Execute
-    let mut res: f64 = op1.sqrt();
-
-    // Rounding
-    match y {
+    let res: f64 = match y {
         1 => unimplemented!(),
         2 => unimplemented!(),
         3 => unimplemented!(),
         4 => unimplemented!(),
-        _ => res = res,
+        _ => op1.sqrt(),
     };
 
     // Store result

--- a/src/machine/behavior/is/float/fsqrt.rs
+++ b/src/machine/behavior/is/float/fsqrt.rs
@@ -9,11 +9,11 @@ pub fn fsqrt(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Rounding
     match y {
-    	1 => unimplemented!(),
-    	2 => unimplemented!(),
-    	3 => unimplemented!(),
-    	4 => unimplemented!(),
-    	_ => res = res,
+        1 => unimplemented!(),
+        2 => unimplemented!(),
+        3 => unimplemented!(),
+        4 => unimplemented!(),
+        _ => res = res,
     };
 
     // Store result

--- a/src/machine/behavior/is/float/fsqrt.rs
+++ b/src/machine/behavior/is/float/fsqrt.rs
@@ -1,6 +1,21 @@
 use machine::state::State;
 
-pub fn fsqrt(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+pub fn fsqrt(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: f64 = state.gpr[z].into();
 
+    // Execute
+    let mut res: f64 = op1.sqrt();
+
+    // Rounding
+    match y {
+    	1 => unimplemented!(),
+    	2 => unimplemented!(),
+    	3 => unimplemented!(),
+    	4 => unimplemented!(),
+    	_ => res = res,
+    };
+
+    // Store result
+    state.gpr[x] = res.into();
+}

--- a/src/machine/behavior/is/float/fsub.rs
+++ b/src/machine/behavior/is/float/fsub.rs
@@ -1,6 +1,13 @@
 use machine::state::State;
 
-pub fn fsub(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
-}
+pub fn fsub(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: f64 = state.gpr[y].into();
+    let op2: f64 = state.gpr[z].into();
 
+    // Execute
+    let res = op1 - op2;
+
+    // Store result
+    state.gpr[x] = res.into();
+}

--- a/src/machine/behavior/is/float/fun.rs
+++ b/src/machine/behavior/is/float/fun.rs
@@ -1,6 +1,19 @@
 use machine::state::State;
+use machine::behavior::is::float::fcmp;
 
-pub fn fun(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+pub fn fun(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: f64 = state.gpr[y].into();
+    let op2: f64 = state.gpr[z].into();
+
+    // Execute
+    if op1.is_nan() && op2.is_nan() {
+    	state.gpr[x] = 0i64.into();
+    } else if op1.is_nan() {
+    	state.gpr[x] = 1i64.into();
+    } else if op2.is_nan() {
+    	state.gpr[x] = (-1 as i64).into();
+    } else {
+    	fcmp(state, x, y, z);
+    }
 }
-

--- a/src/machine/behavior/is/float/fun.rs
+++ b/src/machine/behavior/is/float/fun.rs
@@ -8,12 +8,12 @@ pub fn fun(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Execute
     if op1.is_nan() && op2.is_nan() {
-    	state.gpr[x] = 0i64.into();
+        state.gpr[x] = 0i64.into();
     } else if op1.is_nan() {
-    	state.gpr[x] = 1i64.into();
+        state.gpr[x] = 1i64.into();
     } else if op2.is_nan() {
-    	state.gpr[x] = (-1 as i64).into();
+        state.gpr[x] = (-1 as i64).into();
     } else {
-    	fcmp(state, x, y, z);
+        fcmp(state, x, y, z);
     }
 }

--- a/src/machine/behavior/is/float/fun.rs
+++ b/src/machine/behavior/is/float/fun.rs
@@ -1,5 +1,4 @@
 use machine::state::State;
-use machine::behavior::is::float::fcmp;
 
 pub fn fun(state: &mut State, x: u8, y: u8, z: u8) {
     // Load operands
@@ -7,13 +6,14 @@ pub fn fun(state: &mut State, x: u8, y: u8, z: u8) {
     let op2: f64 = state.gpr[z].into();
 
     // Execute
-    if op1.is_nan() && op2.is_nan() {
-        state.gpr[x] = 0i64.into();
-    } else if op1.is_nan() {
-        state.gpr[x] = 1i64.into();
-    } else if op2.is_nan() {
-        state.gpr[x] = (-1 as i64).into();
+    let res: i64 = if op1.is_nan() || op1 > op2 {
+        1
+    } else if op2.is_nan() || op1 < op2 {
+        -1
     } else {
-        fcmp(state, x, y, z);
-    }
+        0
+    };
+
+    // Store result
+    state.gpr[x] = res.into();
 }

--- a/src/machine/behavior/is/float/fune.rs
+++ b/src/machine/behavior/is/float/fune.rs
@@ -8,12 +8,14 @@ pub fn fune(state: &mut State, x: u8, y: u8, z: u8) {
     let eps: f64 = state.sr[R::E].into();
 
     // Execute
-    let res = ((op1 as i64).wrapping_sub(op2 as i64)).abs();
+    let res: i64 = if op1.is_nan() || op1 - op2 > eps {
+        1
+    } else if op2.is_nan() || op1 - op2 < eps {
+        -1
+    } else {
+        0
+    };
 
     // Store result
-    if res >= eps as i64 {
-        state.gpr[x] = 1u64.into();
-    } else {
-        state.gpr[x] = 0u64.into();
-    }
+    state.gpr[x] = res.into();
 }

--- a/src/machine/behavior/is/float/fune.rs
+++ b/src/machine/behavior/is/float/fune.rs
@@ -1,6 +1,19 @@
 use machine::state::State;
+use machine::state::sr::R;
 
-pub fn fune(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+pub fn fune(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: u64 = state.gpr[y].into();
+    let op2: u64 = state.gpr[z].into();
+    let eps: u64 = state.sr[R::E].into();
+
+    // Execute
+    let res = ((op1 as i64).wrapping_sub(op2 as i64)).abs();
+
+    // Store result
+    if res >= eps as i64 {
+    	state.gpr[x] = 1u64.into();
+    } else {
+    	state.gpr[x] = 0u64.into();
+    }
 }
-

--- a/src/machine/behavior/is/float/fune.rs
+++ b/src/machine/behavior/is/float/fune.rs
@@ -3,9 +3,9 @@ use machine::state::sr::R;
 
 pub fn fune(state: &mut State, x: u8, y: u8, z: u8) {
     // Load operands
-    let op1: u64 = state.gpr[y].into();
-    let op2: u64 = state.gpr[z].into();
-    let eps: u64 = state.sr[R::E].into();
+    let op1: f64 = state.gpr[y].into();
+    let op2: f64 = state.gpr[z].into();
+    let eps: f64 = state.sr[R::E].into();
 
     // Execute
     let res = ((op1 as i64).wrapping_sub(op2 as i64)).abs();

--- a/src/machine/behavior/is/float/fune.rs
+++ b/src/machine/behavior/is/float/fune.rs
@@ -12,8 +12,8 @@ pub fn fune(state: &mut State, x: u8, y: u8, z: u8) {
 
     // Store result
     if res >= eps as i64 {
-    	state.gpr[x] = 1u64.into();
+        state.gpr[x] = 1u64.into();
     } else {
-    	state.gpr[x] = 0u64.into();
+        state.gpr[x] = 0u64.into();
     }
 }

--- a/src/machine/behavior/is/float/ldsf.rs
+++ b/src/machine/behavior/is/float/ldsf.rs
@@ -1,6 +1,17 @@
 use machine::state::State;
+use machine::state::mem::TetraAt;
 
-pub fn ldsf(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+pub fn ldsf(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operand
+    let op1: u64 = state.gpr[y].into();
+    let op2: u64 = state.gpr[z].into();
+
+    // Execute
+    let a = op1.wrapping_add(op2);
+
+    // Load from memory
+    let res: f32 = state.mem[TetraAt(a)].into();
+
+    // Store result
+    state.gpr[x] = (res as f64).into();
 }
-

--- a/src/machine/behavior/is/float/ldsfi.rs
+++ b/src/machine/behavior/is/float/ldsfi.rs
@@ -1,6 +1,16 @@
 use machine::state::State;
+use machine::state::mem::TetraAt;
 
-pub fn ldsfi(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+pub fn ldsfi(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operand
+    let op1: u64 = state.gpr[y].into();
+
+    // Execute
+    let a = op1.wrapping_add(z as u64);
+
+    // Load from memory
+    let res: f32 = state.mem[TetraAt(a)].into();
+
+    // Store result
+    state.gpr[x] = (res as f64).into();
 }
-

--- a/src/machine/behavior/is/float/stsf.rs
+++ b/src/machine/behavior/is/float/stsf.rs
@@ -1,6 +1,17 @@
 use machine::state::State;
+use machine::state::mem::TetraAt;
 
-pub fn stsf(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+pub fn stsf(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operands
+    let op1: u64 = state.gpr[y].into();
+    let op2: u64 = state.gpr[z].into();
+
+    // Execute
+    let a = op1.wrapping_add(op2);
+
+    // Load x
+    let res: f64 = state.gpr[x].into();
+
+    // Store in memory
+    state.mem[TetraAt(a)] = (res as f32).into();
 }
-

--- a/src/machine/behavior/is/float/stsf.rs
+++ b/src/machine/behavior/is/float/stsf.rs
@@ -3,8 +3,8 @@ use machine::state::mem::TetraAt;
 
 pub fn stsf(state: &mut State, x: u8, y: u8, z: u8) {
     // Load operands
-    let op1: u64 = state.gpr[y].into();
-    let op2: u64 = state.gpr[z].into();
+    let op1: f64 = state.gpr[y].into();
+    let op2: f64 = state.gpr[z].into();
 
     // Execute
     let a = op1.wrapping_add(op2);

--- a/src/machine/behavior/is/float/stsf.rs
+++ b/src/machine/behavior/is/float/stsf.rs
@@ -3,8 +3,8 @@ use machine::state::mem::TetraAt;
 
 pub fn stsf(state: &mut State, x: u8, y: u8, z: u8) {
     // Load operands
-    let op1: f64 = state.gpr[y].into();
-    let op2: f64 = state.gpr[z].into();
+    let op1: u64 = state.gpr[y].into();
+    let op2: u64 = state.gpr[z].into();
 
     // Execute
     let a = op1.wrapping_add(op2);

--- a/src/machine/behavior/is/float/stsfi.rs
+++ b/src/machine/behavior/is/float/stsfi.rs
@@ -1,6 +1,16 @@
 use machine::state::State;
+use machine::state::mem::TetraAt;
 
-pub fn stsfi(_state: &mut State, _x: u8, _y: u8, _z: u8) {
-    unimplemented!();
+pub fn stsfi(state: &mut State, x: u8, y: u8, z: u8) {
+    // Load operand
+    let op1: u64 = state.gpr[y].into();
+
+    // Execute
+    let a = op1.wrapping_add(z as u64);
+
+    // Load x
+    let res: f64 = state.gpr[x].into();
+
+    // Store in memory
+    state.mem[TetraAt(a)] = (res as f32).into();
 }
-

--- a/src/machine/behavior/is/float/stsfi.rs
+++ b/src/machine/behavior/is/float/stsfi.rs
@@ -3,7 +3,7 @@ use machine::state::mem::TetraAt;
 
 pub fn stsfi(state: &mut State, x: u8, y: u8, z: u8) {
     // Load operand
-    let op1: u64 = state.gpr[y].into();
+    let op1: f64 = state.gpr[y].into();
 
     // Execute
     let a = op1.wrapping_add(z as u64);

--- a/src/machine/behavior/is/float/stsfi.rs
+++ b/src/machine/behavior/is/float/stsfi.rs
@@ -3,7 +3,7 @@ use machine::state::mem::TetraAt;
 
 pub fn stsfi(state: &mut State, x: u8, y: u8, z: u8) {
     // Load operand
-    let op1: f64 = state.gpr[y].into();
+    let op1: u64 = state.gpr[y].into();
 
     // Execute
     let a = op1.wrapping_add(z as u64);


### PR DESCRIPTION
except for 'sflot'/'sflotu'/'sfloti'/'sflotui'

At some instructions one can hand over a rounding mode which partly was a bit difficult. Therefore I only work with these modi while casting a float to an integer and otherwise I drop it.