### PR TITLE
Fix implementation of jmpb

### DIFF
--- a/src/machine/behavior/is/control/jmpb.rs
+++ b/src/machine/behavior/is/control/jmpb.rs
@@ -8,7 +8,7 @@ pub fn jmpb(state: &mut State, x: u8, y: u8, z: u8) {
     let at: u64 = state.pc.into();
 
     // Execute
-    let ra: u64 = at + 4 * (xyz - 2u64.pow(24u32));
+    let ra: u64 = at - 4 * xyz;
 
     // Store result
     state.pc = ra.into();


### PR DESCRIPTION
All backwards jumps / branches resulted in a panic due to underflow.
This is a hotfix only for jmpb since this is the command used in our example program.
The remaining backwards commands should be reviewed later with more time on hand.